### PR TITLE
Remove step count limit in text generation

### DIFF
--- a/packages/giselle/src/engine/generations/generate-text.ts
+++ b/packages/giselle/src/engine/generations/generate-text.ts
@@ -14,7 +14,7 @@ import {
 	hasCapability,
 	languageModels,
 } from "@giselle-sdk/language-model";
-import { AISDKError, stepCountIs, streamText } from "ai";
+import { AISDKError, streamText } from "ai";
 import type {
 	FailedGeneration,
 	GenerationOutput,
@@ -224,7 +224,6 @@ export function generateText(args: {
 						),
 					);
 				},
-				stopWhen: stepCountIs(Object.keys(preparedToolSet.toolSet).length + 1),
 				async onFinish() {
 					try {
 						await Promise.all(


### PR DESCRIPTION
## Summary
This PR removes the artificial step count limit that was restricting tool execution during text generation.

## Changes
- Removed `stopWhen` parameter that limited tool execution steps
- Removed unused `stepCountIs` import from ai package

## Motivation
The step count limit was preventing the text generation process from fully utilizing available tools when needed. By removing this limit, the system can now execute tools as many times as necessary to complete the generation task.

## Impact
This change allows for more flexible and complete text generation workflows, especially in scenarios requiring multiple tool invocations.