### PR TITLE
feat: add GPT-5-codex model to existing GPT-5 series

### DIFF
--- a/packages/language-model/src/costs/index.test.ts
+++ b/packages/language-model/src/costs/index.test.ts
@@ -30,6 +30,19 @@ describe("calculateDisplayCost", () => {
 		});
 	});
 
+	it("should calculate display cost for OpenAI gpt-5-codex model", async () => {
+		const result = await calculateDisplayCost("openai", "gpt-5-codex", {
+			inputTokens: 1000,
+			outputTokens: 500,
+		});
+
+		expect(result).toEqual({
+			inputCostForDisplay: 0.00125,
+			outputCostForDisplay: 0.005,
+			totalCostForDisplay: 0.00625,
+		});
+	});
+
 	describe("Floating point precision", () => {
 		it("should handle very small token counts precisely", async () => {
 			const result = await calculateDisplayCost("openai", "gpt-5", {

--- a/packages/language-model/src/costs/model-prices.ts
+++ b/packages/language-model/src/costs/model-prices.ts
@@ -25,6 +25,21 @@ export const openAiTokenPricing: ModelPriceTable = {
 			},
 		],
 	},
+	"gpt-5-codex": {
+		prices: [
+			{
+				validFrom: "2025-09-15T00:00:00Z",
+				price: {
+					input: {
+						costPerMegaToken: 1.25,
+					},
+					output: {
+						costPerMegaToken: 10.0,
+					},
+				},
+			},
+		],
+	},
 	"gpt-5-mini": {
 		prices: [
 			{

--- a/packages/language-model/src/openai.test.ts
+++ b/packages/language-model/src/openai.test.ts
@@ -5,11 +5,16 @@ describe("openai llm", () => {
 	describe("OpenAILanguageModelId", () => {
 		it("should map GPT-5 models correctly", () => {
 			expect(OpenAILanguageModelId.parse("gpt-5")).toBe("gpt-5");
+			expect(OpenAILanguageModelId.parse("gpt-5-codex")).toBe("gpt-5-codex");
 			expect(OpenAILanguageModelId.parse("gpt-5-mini")).toBe("gpt-5-mini");
 			expect(OpenAILanguageModelId.parse("gpt-5-nano")).toBe("gpt-5-nano");
 		});
 
 		it("should fallback deprecated models to GPT-5 series", () => {
+			expect(OpenAILanguageModelId.parse("gpt-5-codex-20250915")).toBe(
+				"gpt-5-codex",
+			);
+
 			// Fallback to gpt-5
 			expect(OpenAILanguageModelId.parse("gpt-4o")).toBe("gpt-5");
 			expect(OpenAILanguageModelId.parse("o3")).toBe("gpt-5");

--- a/packages/language-model/src/openai.ts
+++ b/packages/language-model/src/openai.ts
@@ -28,12 +28,16 @@ const defaultConfigurations: OpenAILanguageModelConfigurations = {
 };
 
 export const OpenAILanguageModelId = z
-	.enum(["gpt-5", "gpt-5-mini", "gpt-5-nano"])
+	.enum(["gpt-5", "gpt-5-codex", "gpt-5-mini", "gpt-5-nano"])
 	.catch((ctx) => {
 		if (typeof ctx.value !== "string") {
 			return "gpt-5-nano";
 		}
 		const v = ctx.value;
+
+		if (/^gpt-5-codex(?:-.+)?$/.test(v)) {
+			return "gpt-5-codex";
+		}
 
 		// Fallback to gpt-5
 		if (
@@ -86,6 +90,18 @@ const gpt5: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
+const gpt5codex: OpenAILanguageModel = {
+	provider: "openai",
+	id: "gpt-5-codex",
+	capabilities:
+		Capability.ImageFileInput |
+		Capability.TextGeneration |
+		Capability.OptionalSearchGrounding |
+		Capability.Reasoning,
+	tier: Tier.enum.pro,
+	configurations: defaultConfigurations,
+};
+
 const gpt5mini: OpenAILanguageModel = {
 	provider: "openai",
 	id: "gpt-5-mini",
@@ -109,7 +125,7 @@ const gpt5nano: OpenAILanguageModel = {
 	configurations: defaultConfigurations,
 };
 
-export const models = [gpt5, gpt5mini, gpt5nano];
+export const models = [gpt5, gpt5codex, gpt5mini, gpt5nano];
 
 export const LanguageModel = OpenAILanguageModel;
 export type LanguageModel = OpenAILanguageModel;


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes and the purpose of the PR. -->
This PR adds support for the GPT-5-codex model to the existing GPT-5 series in the language model package. This extends the available OpenAI model options for users who need code-optimized language models.

## Related Issue
<!-- Mention the related issue number if applicable. -->
N/A

## Changes
<!-- List the main changes made in this PR. -->
- Add GPT-5-codex model configuration with same capabilities as GPT-5
- Add pricing information for GPT-5-codex (same as GPT-5)
- Update model ID parser to handle gpt-5-codex and its variants
- Add test cases for GPT-5-codex model parsing and cost calculation

## Testing
<!-- Briefly describe the testing steps or results. -->
All tests pass successfully:
- Model ID parsing correctly handles `gpt-5-codex` and variants like `gpt-5-codex-20250915`
- Cost calculation tests verify correct pricing for GPT-5-codex ($1.25 per mega token for input, $10.0 per mega token for output)
- Existing GPT-5 series models (gpt-5, gpt-5-mini, gpt-5-nano) continue to work as expected
- Test suite: `pnpm -F @giselle-sdk/language-model test` - All 40 tests pass

## Other Information
<!-- Add any other relevant information for the reviewer. -->
- GPT-5-codex is configured as a Pro tier model with the same capabilities as GPT-5: ImageFileInput, TextGeneration, OptionalSearchGrounding, and Reasoning
- The model follows the same fallback pattern as other GPT-5 series models for backward compatibility
- No breaking changes to existing functionality